### PR TITLE
Bump to v2023.1.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,5 +22,5 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
-        name: powsybl-distribution-2023.0.0
-        path: target/powsybl-distribution-2023.0.0
+        name: powsybl-distribution-2023.1.0
+        path: target/powsybl-distribution-2023.1.0

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </parent>
     <artifactId>powsybl-distribution</artifactId>
     <packaging>pom</packaging>
-    <version>2023.0.0</version>
+    <version>2023.1.0</version>
 
     <properties>
         <java.version>11</java.version>
@@ -56,7 +56,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <packageName>powsybl-distribution-2023.0.0</packageName>
+                    <packageName>powsybl-distribution-2023.1.0</packageName>
                     <copyToEtc>
                         <files>
                             <file>${project.basedir}/resources/config/config.yml</file>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <properties>
         <java.version>11</java.version>
-        <logback.version>1.2.0</logback.version>
+        <logback.version>1.2.9</logback.version>
         <powsybldependencies.version>2023.1.0</powsybldependencies.version>
         <slf4j.version>1.7.22</slf4j.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <java.version>11</java.version>
         <logback.version>1.2.0</logback.version>
-        <powsybldependencies.version>2023.0.0</powsybldependencies.version>
+        <powsybldependencies.version>2023.1.0</powsybldependencies.version>
         <slf4j.version>1.7.22</slf4j.version>
     </properties>
 
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>com.powsybl</groupId>
                 <artifactId>powsybl-itools-packager-maven-plugin</artifactId>
-                <version>5.1.1</version>
+                <version>5.2.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?**
Update versions to last release train for 2023.1.0 release



**What is the current behavior?**
- v2023.0.0
- powsybl-dependencies 2023.0.0
- logback 1.2.0
- powsybl-itools-packager-maven-plugin 5.1.1



**What is the new behavior (if this is a feature change)?**
- v2023.1.0
- powsybl-dependencies 2023.1.0
- logback 1.2.9
- powsybl-itools-packager-maven-plugin 5.2.0

