### PR TITLE
Prepare v2023.2.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Actions Status](https://github.com/powsybl/powsybl-distribution/workflows/CI/badge.svg)](https://github.com/powsybl/powsybl-distribution/actions)
 [![MPL-2.0 License](https://img.shields.io/badge/license-MPL_2.0-blue.svg)](https://www.mozilla.org/en-US/MPL/2.0/)
-[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/powsybl)
 [![Slack](https://img.shields.io/badge/slack-powsybl-blueviolet.svg?logo=slack)](https://join.slack.com/t/powsybl/shared_invite/zt-rzvbuzjk-nxi0boim1RKPS5PjieI0rA)
 
 PowSyBl (**Pow**er **Sy**stem **Bl**ocks) is an open source framework written in Java, that makes it easy to write complex

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </parent>
     <artifactId>powsybl-distribution</artifactId>
     <packaging>pom</packaging>
-    <version>2023.2.1</version>
+    <version>2023.3.0-SNAPSHOT</version>
 
     <properties>
         <java.version>11</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,12 +20,13 @@
     </parent>
     <artifactId>powsybl-distribution</artifactId>
     <packaging>pom</packaging>
-    <version>2023.2.0-SNAPSHOT</version>
+    <version>2023.2.1</version>
 
     <properties>
         <java.version>11</java.version>
         <logback.version>1.2.9</logback.version>
-        <powsybl-dependencies.version>2023.1.0</powsybl-dependencies.version>
+        <powsybl-dependencies.version>2023.2.1</powsybl-dependencies.version>
+        <powsybl-core.version>5.3.1</powsybl-core.version> <!--pom import does not reach the build/plugins part-->
         <slf4j.version>1.7.22</slf4j.version>
     </properties>
 
@@ -46,7 +47,7 @@
             <plugin>
                 <groupId>com.powsybl</groupId>
                 <artifactId>powsybl-itools-packager-maven-plugin</artifactId>
-                <version>5.2.0</version>
+                <version>${powsybl-core.version}</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?**
Update versions to last release train for 2023.1.0 release



**What is the current behavior?**
2023.2.0-SNAPSHOT based on powsybl-dependencies 2023.1.0 and powsybl-itools-packager-maven-plugin 5.2.0



**What is the new behavior (if this is a feature change)?**
- first commit: 2023.2.1 based on powsybl-dependencies 2023.2.1 and powsybl-itools-packager-maven-plugin 5.3.1
- second commit: 2023.3.0-SNAPSHOT

**DO NOT** squash the commits