### PR TITLE
Fix logback-classic dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
 
     <properties>
         <java.version>17</java.version>
-        <logback.version>1.4.14</logback.version>
         <powsybl-dependencies.version>2024.4.1</powsybl-dependencies.version>
         <powsybl-core.version>6.6.1</powsybl-core.version> <!--pom import does not reach the build/plugins part-->
         <slf4j.version>2.0.9</slf4j.version>
@@ -91,7 +90,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [X] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->
An old `logback-classic` version was indicated in the `pom.xml`. It is incompatible with the logback version used by `powsybl-core`.


**What is the new behavior (if this is a feature change)?**
No `logback-classic` version is indicated in the `pom.xml`. It now uses the powsybl-core logkback version.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
